### PR TITLE
Optimize RapidJSON benchmark

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -948,21 +948,21 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
 {
    writer.StartObject();
 
-   writer.String("int_array");
+   writer.String("int_array", 9);
    writer.StartArray();
    for (auto& v : obj.int_array) {
       writer.Int(v);
    }
    writer.EndArray();
 
-   writer.String("float_array");
+   writer.String("float_array", 11);
    writer.StartArray();
    for (auto& v : obj.float_array) {
       writer.Double(v);
    }
    writer.EndArray();
 
-   writer.String("double_array");
+   writer.String("double_array", 12);
    writer.StartArray();
    for (auto& v : obj.double_array) {
       writer.Double(v);
@@ -985,16 +985,16 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
 {
    writer.StartObject();
 
-   writer.String("name0");
-   writer.String(obj.name0.c_str());
-   writer.String("name1");
-   writer.String(obj.name1.c_str());
-   writer.String("name2");
-   writer.String(obj.name2.c_str());
-   writer.String("name3");
-   writer.String(obj.name3.c_str());
-   writer.String("name4");
-   writer.String(obj.name4.c_str());
+   writer.String("name0", 5);
+   writer.String(obj.name0.c_str(), obj.name0.size());
+   writer.String("name1", 5);
+   writer.String(obj.name1.c_str(), obj.name1.size());
+   writer.String("name2", 5);
+   writer.String(obj.name2.c_str(), obj.name2.size());
+   writer.String("name3", 5);
+   writer.String(obj.name3.c_str(), obj.name3.size());
+   writer.String("name4", 5);
+   writer.String(obj.name4.c_str(), obj.name4.size());
 
    writer.EndObject();
 }
@@ -1016,7 +1016,7 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
 {
    writer.StartObject();
 
-   writer.String("v3s");
+   writer.String("v3s", 3);
    writer.StartArray();
    for (auto& v3 : obj.v3s) {
       writer.StartArray();
@@ -1027,8 +1027,8 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
    }
    writer.EndArray();
 
-   writer.String("id");
-   writer.String(obj.id.c_str());
+   writer.String("id", 2);
+   writer.String(obj.id.c_str(), obj.id.size());
 
    writer.EndObject();
 }
@@ -1045,13 +1045,13 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
 {
    writer.StartObject();
 
-   writer.String("string");
-   writer.String(obj.string.c_str());
-   writer.String("another_string");
-   writer.String(obj.another_string.c_str());
-   writer.String("boolean");
+   writer.String("string", 6);
+   writer.String(obj.string.c_str(), obj.string.size());
+   writer.String("another_string", 14);
+   writer.String(obj.another_string.c_str(), obj.another_string.size());
+   writer.String("boolean", 7);
    writer.Bool(obj.boolean);
-   writer.String("nested_object");
+   writer.String("nested_object", 13);
    rapid_json_write(writer, obj.nested_object);
 
    writer.EndObject();
@@ -1078,36 +1078,36 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
 {
    writer.StartObject();
 
-   writer.String("fixed_object");
+   writer.String("fixed_object", 12);
    rapid_json_write(writer, obj.fixed_object);
-   writer.String("fixed_name_object");
+   writer.String("fixed_name_object", 17);
    rapid_json_write(writer, obj.fixed_name_object);
-   writer.String("another_object");
+   writer.String("another_object", 14);
    rapid_json_write(writer, obj.another_object);
 
-   writer.String("string_array");
+   writer.String("string_array", 12);
    writer.StartArray();
    for (auto& v : obj.string_array) {
-      writer.String(v.c_str());
+      writer.String(v.c_str(), v.size());
    }
    writer.EndArray();
 
-   writer.String("string");
-   writer.String(obj.string.c_str());
-   writer.String("number");
+   writer.String("string", 6);
+   writer.String(obj.string.c_str(), obj.string.size());
+   writer.String("number", 6);
    writer.Double(obj.number);
-   writer.String("boolean");
+   writer.String("boolean", 7);
    writer.Bool(obj.boolean);
-   writer.String("another_bool");
+   writer.String("another_bool", 12);
    writer.Bool(obj.another_bool);
 
    writer.EndObject();
 }
 
 auto rapidjson_read(obj_t& obj, const std::string& buffer){
-
+   std::string bufferCopy{buffer};
    rapidjson::Document doc;
-	doc.Parse(buffer.c_str());
+	doc.ParseInsitu(bufferCopy.data());
    rapid_json_read(doc, obj);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1104,10 +1104,10 @@ void rapid_json_write(rapidjson::Writer<rapidjson::StringBuffer>& writer, const 
    writer.EndObject();
 }
 
-auto rapidjson_read(obj_t& obj, const std::string& buffer){
-   std::string bufferCopy{buffer};
+auto rapidjson_read(obj_t& obj, const std::string& buffer, std::string& mutable_buffer){
+   mutable_buffer = buffer;
    rapidjson::Document doc;
-	doc.ParseInsitu(bufferCopy.data());
+	doc.ParseInsitu(mutable_buffer.data());
    rapid_json_read(doc, obj);
 }
 
@@ -1126,9 +1126,11 @@ auto rapidjson_test()
    
    auto t0 = std::chrono::steady_clock::now();
    
+   std::string mutable_buffer{};
+   
    try {
       for (size_t i = 0; i < iterations; ++i) {
-         rapidjson_read(obj, buffer);
+         rapidjson_read(obj, buffer, mutable_buffer);
          rapidjson_write(obj, buffer);
       }
    } catch (const std::exception& e) {
@@ -1157,7 +1159,7 @@ auto rapidjson_test()
    t0 = std::chrono::steady_clock::now();
    
    for (size_t i = 0; i < iterations; ++i) {
-      rapidjson_read(obj, buffer);
+      rapidjson_read(obj, buffer, mutable_buffer);
    }
    
    t1 = std::chrono::steady_clock::now();


### PR DESCRIPTION
Although it's "only" about 10% read improvement, it does paint a better picture of the best RapidJSON has to offer. For write, it seems that the noise in measurement makes it hard to paint a clearer picture.

**Before:**
```
oipo@oipo-X670E-AORUS-MASTER:~/Programming/json_performance/build$ taskset 0x1 ../json_performance_old 
Glaze json roundtrip: 0.909552 s
Glaze json byte length: 616
Glaze json write: 0.34468 s, 1704.37 MB/s
Glaze json read: 0.476036 s, 1234.07 MB/s

Glaze binary roundtrip: 0.17668 s
Glaze binary byte length: 350
Glaze binary write: 0.082596 s, 4041.19 MB/s
Glaze binary read: 0.089616 s, 3724.63 MB/s

---

simdjson (on demand) json byte length: 617
simdjson (on demand) json read: 0.30734 s, 1914.55 MB/s

---

daw_json_link json roundtrip: 1.9158 s
daw_json_link json byte length: 618
daw_json_link json write: 0.974278 s, 604.931 MB/s
daw_json_link json read: 0.831569 s, 708.745 MB/s

---

RapidJSON json roundtrip: 2.00913 s
RapidJSON json byte length: 694
RapidJSON json write: 1.02072 s, 648.417 MB/s
RapidJSON json read: 0.919124 s, 720.088 MB/s

---

json_struct json roundtrip: 3.41012 s
json_struct json byte length: 616
json_struct json write: 1.81378 s, 323.888 MB/s
json_struct json read: 1.31156 s, 447.911 MB/s

---

nlohmann json roundtrip: 10.2245 s
nlohmann json byte length: 695
nlohmann json write: 4.41752 s, 150.04 MB/s
nlohmann json read: 5.47521 s, 121.055 MB/s

---

Glaze json roundtrip: 2.06549 s
Glaze json byte length: 101297
Glaze json write: 0.436738 s, 2211.95 MB/s
Glaze json read: 1.62964 s, 592.797 MB/s

---

simdjson (on demand) json byte length: 101297
simdjson (on demand) json read: 35.8402 s, 26.9542 MB/s

---
```

**After:**
```
oipo@oipo-X670E-AORUS-MASTER:~/Programming/json_performance/build$ taskset 0x1 ../json_performance_new_insitu 
Glaze json roundtrip: 0.919169 s
Glaze json byte length: 616
Glaze json write: 0.343012 s, 1712.66 MB/s
Glaze json read: 0.495572 s, 1185.42 MB/s

Glaze binary roundtrip: 0.173884 s
Glaze binary byte length: 350
Glaze binary write: 0.082901 s, 4026.32 MB/s
Glaze binary read: 0.08958 s, 3726.12 MB/s

---

simdjson (on demand) json byte length: 617
simdjson (on demand) json read: 0.314004 s, 1873.92 MB/s

---

daw_json_link json roundtrip: 1.99827 s
daw_json_link json byte length: 618
daw_json_link json write: 0.881563 s, 668.552 MB/s
daw_json_link json read: 0.824215 s, 715.069 MB/s

---

RapidJSON json roundtrip: 1.96398 s
RapidJSON json byte length: 694
RapidJSON json write: 1.07056 s, 618.23 MB/s
RapidJSON json read: 0.811009 s, 816.082 MB/s

---

json_struct json roundtrip: 3.39369 s
json_struct json byte length: 616
json_struct json write: 1.85363 s, 316.926 MB/s
json_struct json read: 1.37011 s, 428.771 MB/s

---

nlohmann json roundtrip: 10.2876 s
nlohmann json byte length: 695
nlohmann json write: 4.46004 s, 148.609 MB/s
nlohmann json read: 5.51013 s, 120.288 MB/s

---

Glaze json roundtrip: 2.0633 s
Glaze json byte length: 101297
Glaze json write: 0.436987 s, 2210.69 MB/s
Glaze json read: 1.62957 s, 592.821 MB/s

---

simdjson (on demand) json byte length: 101297
simdjson (on demand) json read: 34.0108 s, 28.404 MB/s

---
```