### PR TITLE
Add Qt Json benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,14 @@ add_executable(${PROJECT_NAME} src/main.cpp)
 
 target_include_directories(${PROJECT_NAME} PRIVATE include ${json_struct_SOURCE_DIR}/include ${rapidjson_SOURCE_DIR}/include)
 
+find_package(Qt5 COMPONENTS Core)
+
 target_link_libraries(${PROJECT_NAME} PRIVATE nlohmann_json::nlohmann_json glaze::glaze daw::daw-json-link simdjson yyjson fmt::fmt)
+
+if (Qt5_FOUND)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_QT=1)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core)
+endif()
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 


### PR DESCRIPTION
Qt is a popular gui framework that has its own json library. This PR adds an optional benchmark for Qt that will be run if Qt is found on the system.

Results on my system (Ryzen 4700 U, 16G):

| Library                                                      | Roundtrip Time (s) | Write (MB/s) | Read (MB/s) |
| ------------------------------------------------------------ | ------------------ | ------------ | ----------- |
| [**Glaze**](https://github.com/stephenberry/glaze) | **1.62** | **720** | **802** |
| [**simdjson (on demand)**](https://github.com/simdjson/simdjson) | **N/A** | **N/A** | **842** |
| [**yyjson**](https://github.com/ibireme/yyjson) | **2.25** | **543** | **708** |
| [**daw_json_link**](https://github.com/beached/daw_json_link) | **3.57** | **293** | **409** |
| [**RapidJSON**](https://github.com/Tencent/rapidjson) | **3.70** | **337** | **405** |
| [**json_struct**](https://github.com/jorgen/json_struct) | **6.38** | **194** | **185** |
| [**nlohmann**](https://github.com/nlohmann/json) | **20.17** | **81** | **56** |
| [**qtjson**](https://www.qt.io/) | **36.57** | **27** | **55** |